### PR TITLE
set RANGE, TYPE and VALUE extensions in hostinfo to false 

### DIFF
--- a/vrc-oscquery-lib/HostInfo.cs
+++ b/vrc-oscquery-lib/HostInfo.cs
@@ -12,9 +12,9 @@ namespace VRC.OSCQuery
         {
             { Attributes.ACCESS, true },
             { Attributes.CLIPMODE, false },
-            { Attributes.RANGE, true },
-            { Attributes.TYPE, true },
-            { Attributes.VALUE, true },
+            { Attributes.RANGE, false },
+            { Attributes.TYPE, false },
+            { Attributes.VALUE, false },
         };
         
         [JsonProperty(Keys.OSC_IP)]


### PR DESCRIPTION
because they are actually not implemented. ie. queries like: https://localhost:port/foo?VALUE don't return following the oscquery specification.