### PR TITLE
Allow custom websocket implementations

### DIFF
--- a/vrc-oscquery-lib/Attributes.cs
+++ b/vrc-oscquery-lib/Attributes.cs
@@ -76,7 +76,7 @@ namespace VRC.OSCQuery
         public const string TAGS = "TAGS";
         public const string UNIT = "UNIT";
         public const string VALUE = "VALUE";
-
+        public const string LISTEN = "LISTEN";
         #endregion
         
         #region Service Types

--- a/vrc-oscquery-lib/HostInfo.cs
+++ b/vrc-oscquery-lib/HostInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Net;
 using Newtonsoft.Json;
 
 namespace VRC.OSCQuery
@@ -26,6 +27,12 @@ namespace VRC.OSCQuery
         [JsonProperty(Keys.OSC_TRANSPORT)] 
         public string oscTransport = Keys.OSC_TRANSPORT_UDP;
 
+        [JsonProperty(Keys.WS_IP)]
+        public string wsIP = IPAddress.Loopback.ToString();
+
+        [JsonProperty(Keys.WS_PORT)]
+        public int wsPort = OSCQueryService.DefaultPortHttp;
+
         /// <summary>
         /// Empty Constructor required for JSON Serialization
         /// </summary>
@@ -48,6 +55,8 @@ namespace VRC.OSCQuery
             public const string OSC_PORT = "OSC_PORT";
             public const string OSC_TRANSPORT = "OSC_TRANSPORT";
             public const string OSC_TRANSPORT_UDP = "UDP";
+            public const string WS_IP = "WS_IP";
+            public const string WS_PORT = "WS_PORT";
         }
     }
 }

--- a/vrc-oscquery-lib/OSCQueryService.cs
+++ b/vrc-oscquery-lib/OSCQueryService.cs
@@ -22,6 +22,12 @@ namespace VRC.OSCQuery
             set => HostInfo.oscPort = value;
         }
 
+        public int WsPort
+        {
+            get => HostInfo.wsPort;
+            set => HostInfo.wsPort = value;
+        }
+
         public string ServerName {
             get => HostInfo.name;
             set => HostInfo.name = value;
@@ -29,7 +35,8 @@ namespace VRC.OSCQuery
         
         public IPAddress HostIP { get; set; } = IPAddress.Loopback;
         public IPAddress OscIP { get; set; } = IPAddress.Loopback;
-        
+        public IPAddress WsIP { get; set; } = IPAddress.Loopback;
+
         public static ILogger<OSCQueryService> Logger { get; set; } = new NullLogger<OSCQueryService>();
 
         public void AddMiddleware(Func<HttpListenerContext, Action, Task> middleware)

--- a/vrc-oscquery-lib/OSCQueryServiceBuilder.cs
+++ b/vrc-oscquery-lib/OSCQueryServiceBuilder.cs
@@ -67,6 +67,20 @@ namespace VRC.OSCQuery
             return this;
         }
 
+        public OSCQueryServiceBuilder WithWsPort(int port)
+        {
+            _customStartup = true;
+            _service.WsPort = port;
+            return this;
+        }
+
+        public OSCQueryServiceBuilder WithWsIP(IPAddress address)
+        {
+            _customStartup = true;
+            _service.WsIP = address;
+            return this;
+        }
+
         public OSCQueryServiceBuilder StartHttpServer()
         {
             _customStartup = true;


### PR DESCRIPTION
By adding WS_PORT and WS_IP to the HostInfo as defined in the [OSCQuery required attributes](https://github.com/Vidvox/OSCQueryProposal#required-attributes), we can implement the bi-directional websocket support outside of this library.