### PR TITLE
Add MeaMod tests for Discover / Drop OSCQuery Services

### DIFF
--- a/Tests/vrc-oscquery-tests/MeaModDiscoveryTests.cs
+++ b/Tests/vrc-oscquery-tests/MeaModDiscoveryTests.cs
@@ -9,8 +9,7 @@ public class MeaModDiscoveryTests
     [Test]
     public async Task Discovery_WhenOSCQueryServiceAdvertised_ContainsService()
     {
-        // Arrange
-        // var loggerMock = new Mock<ILogger<OSCQueryService>>();
+        // Set up Advertising and Discovery
         var advertiser = new MeaModDiscovery();
         var discoverer = new MeaModDiscovery();
         var oscQueryServiceProfile = new OSCQueryServiceProfile
@@ -21,25 +20,24 @@ public class MeaModDiscoveryTests
             OSCQueryServiceProfile.ServiceType.OSCQuery
         );
 
-        // Act
+        // Advertise the service, Refresh the services, and wait for the service to be discovered
         advertiser.Advertise(oscQueryServiceProfile);
         await Task.Delay(DELAY_TIME_MS); // Wait for the service to be advertised
         discoverer.RefreshServices();
         await Task.Delay(DELAY_TIME_MS); // Wait for the service to be discovered
 
-        // Assert
+        // Assert that the service was discovered
         var discoveredServices = discoverer.GetOSCQueryServices();
         Assert.Contains(oscQueryServiceProfile, discoveredServices.ToList());
 
-        // Cleanup
+        // Stop advertising the service
         advertiser.Unadvertise(oscQueryServiceProfile);
     }
     
     [Test]
     public async Task Discovery_WhenOSCQueryServiceUnadvertised_DoesNotContainService()
     {
-        // Arrange
-        // var loggerMock = new Mock<ILogger<OSCQueryService>>();
+        // Set up Advertising and Discovery
         var advertiser = new MeaModDiscovery();
         var discoverer = new MeaModDiscovery();
         var oscQueryServiceProfile = new OSCQueryServiceProfile
@@ -50,19 +48,18 @@ public class MeaModDiscoveryTests
             OSCQueryServiceProfile.ServiceType.OSCQuery
         );
 
-        // Act
+        // Advertise the service, Refresh the services, and wait for the service to be discovered
         advertiser.Advertise(oscQueryServiceProfile);
         await Task.Delay(DELAY_TIME_MS); // Wait for the service to be advertised
         discoverer.RefreshServices();
         await Task.Delay(DELAY_TIME_MS); // Wait for the service to be discovered
 
-        // Assert
+        // Assert that the service was discovered
         var discoveredServices = discoverer.GetOSCQueryServices();
         Assert.Contains(oscQueryServiceProfile, discoveredServices.ToList());
 
-        // Cleanup
+        // Stop advertising the service, Refresh the services, and wait for the service to be disconnected
         advertiser.Unadvertise(oscQueryServiceProfile);
-        
         discoverer.RefreshServices();
         await Task.Delay(DELAY_TIME_MS); // Wait for the service to be disconnected
         


### PR DESCRIPTION
Adds tests for MeaMod DNS to ensure it can discover an OSCQuery service and catch when it is un-advertised. 

Uses some timeouts, which is not ideal but I haven't found another reliable approach.