### PR TITLE
Fix OSCQuery services being discovered multiple times due to invalid check

### DIFF
--- a/vrc-oscquery-lib/Zeroconf/MeaModDiscovery.cs
+++ b/vrc-oscquery-lib/Zeroconf/MeaModDiscovery.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using MeaMod.DNS.Model;
@@ -156,7 +156,7 @@ namespace VRC.OSCQuery
             else if (string.Compare(serviceName, OSCQueryService._localOscJsonServiceName, StringComparison.Ordinal) == 0 && !_profiles.ContainsValue(profile))
             {
                 // Make sure there's not already a service with the same name
-                if (_oscQueryServices.All(p => !p.name.Equals(profile.InstanceName)))
+                if (_oscQueryServices.All(p => p.name != profile.InstanceName))
                 {
                     var p = new OSCQueryServiceProfile(instanceName, ipAddressList.First(), port, OSCQueryServiceProfile.ServiceType.OSCQuery);
                     _oscQueryServices.Add(p);


### PR DESCRIPTION
When OSC(Query) services are discovered, they are only added if no other service with the same name has already been discovered. For OSC-type services, this works fine. However for OSCQuery-type services, the check is currently invalid, resulting in those services being discovered multiple times.

This PR fixes this issue by instead doing the same check as is being done for OSC-type services.